### PR TITLE
Added support for multiple teleporters per id. Added onEnter and onExit code hooks to the teleports

### DIFF
--- a/addons/main/cfgVehicles.hpp
+++ b/addons/main/cfgVehicles.hpp
@@ -23,6 +23,14 @@ class cfgVehicles {
 
     class Logic;
     class Module_F: Logic {
+        class AttributesBase {
+            class Default;
+            class Edit;
+            class EditMulti5;
+            class Combo;
+            class Checkbox;
+            class ModuleDescription;
+        };
         class ArgumentsBaseUnits {};
         class ModuleDescription {};
     };
@@ -106,12 +114,40 @@ class cfgVehicles {
         isGlobal = 0; //run on server
         isTriggerActivated = 1; //Wait for triggers
         //icon = QPATHTOF(UI\Icon_Module_Make_Unit_Handcuffed_ca.paa);
-        class Arguments {
-            class anomalyId {
+        // class Arguments {
+        //     class anomalyId {
+        //         displayName = "ID";
+        //         description = "$STR_anomaly_teleport_id_desc";
+        //         typeName = "NUMBER";
+        //         defaultValue = 0;
+        //     };
+        // };
+        class Attributes: AttributesBase {
+            class anomalyId: Edit {
                 displayName = "ID";
-                description = "$STR_anomaly_teleport_id_desc";
-                typeName = "NUMBER";
-                defaultValue = 0;
+                tooltip = "$STR_anomaly_teleport_id_desc";
+                property = "anomaly_teleport_id";
+                defaultValue = "0";
+            };
+
+            class onEnterCode {
+                control = "EditCodeMulti5";
+                displayName = "On Enter Code";
+                property = "anomaly_teleport_enterCode";
+                tooltip = "$STR_anomaly_teleport_onEnter_desc";
+                expression = "_this setVariable ['%s',_value,true];";
+                typeName = "STRING";
+                defaultValue = "";
+            };
+
+            class onExitCode {
+                control = "EditCodeMulti5";
+                displayName = "On Exit Code";
+                property = "anomaly_teleport_exitCode";
+                tooltip = "$STR_anomaly_teleport_onExit_desc";
+                expression = "_this setVariable ['%s',_value,true];";
+                typeName = "STRING";
+                defaultValue = "";
             };
         };
         class ModuleDescription: ModuleDescription {

--- a/addons/main/functions/anomalies/fn_activateTeleport.sqf
+++ b/addons/main/functions/anomalies/fn_activateTeleport.sqf
@@ -51,6 +51,8 @@ _proxy = _exit getVariable QGVAR(sound);
             deleteVehicle _x;
         };
     } forEach _list;
+    private _onEnterCode = _trg getVariable ["onEnterCode", {}];
+    private _onExitCode = _exit getVariable ["onExitCode", {}];
     private _exitPos = getPos _exit;
     private _obj = objNull;
     {
@@ -74,7 +76,10 @@ _proxy = _exit getVariable QGVAR(sound);
 
             if (_doTeleport) then {
                 // [_obj, [((_exitPos select 0) + (random 4) - 2), ((_exitPos select 1) + (random 4) - 2), (_exitPos select 2) ]] remoteExec ["setPos", _obj];
+                
+                [_trg, _exit, _obj] call _onEnterCode;
                 _obj setPos [((_exitPos select 0) + (random 4) - 2), ((_exitPos select 1) + (random 4) - 2), (_exitPos select 2) ];
+                [_trg, _exit, _obj] call _onExitCode;
             };
         } else {
             if (!(_obj isKindOf "landvehicle" || _x isKindOf "air")) then {

--- a/addons/main/functions/anomalies/fn_activateTeleport.sqf
+++ b/addons/main/functions/anomalies/fn_activateTeleport.sqf
@@ -77,9 +77,17 @@ _proxy = _exit getVariable QGVAR(sound);
             if (_doTeleport) then {
                 // [_obj, [((_exitPos select 0) + (random 4) - 2), ((_exitPos select 1) + (random 4) - 2), (_exitPos select 2) ]] remoteExec ["setPos", _obj];
                 
-                [_trg, _exit, _obj] call _onEnterCode;
+                try {
+                    [_trg, _exit, _obj] call _onEnterCode;
+                } catch {
+                    hintC ("OnEnter code failed to execute. Affected anomaly at " + str (_pos));
+                };
                 _obj setPos [((_exitPos select 0) + (random 4) - 2), ((_exitPos select 1) + (random 4) - 2), (_exitPos select 2) ];
-                [_trg, _exit, _obj] call _onExitCode;
+                try {
+                    [_trg, _exit, _obj] call _onExitCode;
+                } catch {
+                    hintC ("OnExit code failed to execute. Affected anomaly at " + str (_pos));
+                };
             };
         } else {
             if (!(_obj isKindOf "landvehicle" || _x isKindOf "air")) then {

--- a/addons/main/functions/anomalies/fn_activateTeleport.sqf
+++ b/addons/main/functions/anomalies/fn_activateTeleport.sqf
@@ -30,11 +30,8 @@ if (count _teleporters < 2) exitWith {
 };
 
 private _exit = objNull;
-{
-    if (_trg != _x) then {
-        _exit = _x;
-    };
-} forEach _teleporters;
+_otherTeleporters = _teleporters - [_trg];
+_exit = selectRandom _otherTeleporters;
 
 if (isNull _exit) exitWith {
     hintC ("It was not possible to find an exit for teleport anomaly at " + str(getPos _trg) + " with id " + str(_id) + "!")

--- a/addons/main/functions/anomalies/fn_createTeleport.sqf
+++ b/addons/main/functions/anomalies/fn_createTeleport.sqf
@@ -40,10 +40,6 @@ if (isNil QGVAR(teleportIDs)) then {
 // _teleporters = [GVAR(teleportIDs), _id] call CBA_fnc_hashGet;
 _teleporters = GVAR(teleportIDs) getOrDefault [_id, []];
 
-if ( (count _teleporters) >= 2) exitWith {
-    hintC ("Teleport Anomaly with ID " + str(_id) + " cannot be created as there are already 2 anomalies with that id. Affected anomaly at " + str(_pos));
-};
-
 _trg = createTrigger ["EmptyDetector", _pos];
 _trg setPosASL _pos;
 _teleporters pushBack _trg;

--- a/addons/main/functions/anomalies/fn_createTeleport.sqf
+++ b/addons/main/functions/anomalies/fn_createTeleport.sqf
@@ -28,13 +28,13 @@ if !(_pos isEqualType []) then {
         _onEnterCode = compile _onEnterCode;
     } catch {
         _onEnterCode = {};
-        hintC ("On Enter Code failed to compile. Affected anomaly at " + str (_pos));
+        hintC ("On Enter Code failed to compile. Affected anomaly at " + str (getPosASL _pos));
     };
     try {
         _onExitCode = compile _onExitCode;
     } catch {
         _onExitCode = {};
-        hintC ("On Exit Code failed to compile. Affected anomaly at " + str (_pos));
+        hintC ("On Exit Code failed to compile. Affected anomaly at " + str (getPosASL _pos));
     };
 
     _pos = [_pos] call FUNC(getLocationFromModule);

--- a/addons/main/functions/anomalies/fn_createTeleport.sqf
+++ b/addons/main/functions/anomalies/fn_createTeleport.sqf
@@ -15,12 +15,28 @@
     Author:
     diwako 2017-12-14
 */
-params[["_pos",[0,0,0]],["_id",-1]];
+params[["_pos", [0, 0, 0]], ["_id", -1], ["_onEnterCode", {}], ["_onExitCode", {}]];
 if !(isServer) exitWith {};
 
 if !(_pos isEqualType []) then {
     //created via module
-    _id = _pos getVariable ["anomalyid",-1];
+    _id = _pos getVariable ["anomalyId", -1];
+    _onEnterCode = _pos getVariable ["onEnterCode", ""];
+    _onExitCode = _pos getVariable ["onExitCode", ""];
+
+    try {
+        _onEnterCode = compile _onEnterCode;
+    } catch {
+        _onEnterCode = {};
+        hintC ("On Enter Code failed to compile. Affected anomaly at " + str (_pos));
+    };
+    try {
+        _onExitCode = compile _onExitCode;
+    } catch {
+        _onExitCode = {};
+        hintC ("On Exit Code failed to compile. Affected anomaly at " + str (_pos));
+    };
+
     _pos = [_pos] call FUNC(getLocationFromModule);
 };
 
@@ -43,6 +59,8 @@ _teleporters = GVAR(teleportIDs) getOrDefault [_id, []];
 _trg = createTrigger ["EmptyDetector", _pos];
 _trg setPosASL _pos;
 _teleporters pushBack _trg;
+_trg setVariable ["onEnterCode", _onEnterCode];
+_trg setVariable ["onExitCode", _onExitCode];
 // [GVAR(teleportIDs), _id, _teleporters] call CBA_fnc_hashSet;
 GVAR(teleportIDs) set [_id, _teleporters];
 _trg setVariable [QGVAR(cooldown), false, true];

--- a/addons/main/functions/anomalies/fn_deleteAnomalies.sqf
+++ b/addons/main/functions/anomalies/fn_deleteAnomalies.sqf
@@ -36,11 +36,7 @@ private _type = "";
                 private _id = _x getVariable QGVAR(teleportID);
                 // _teleporters = [GVAR(teleportIDs), _id] call CBA_fnc_hashGet;
                 private _teleporters = GVAR(teleportIDs) get _id;
-                for "_i" from 0 to ((count _teleporters) -1 ) do {
-                    if ( (_teleporters select _i) == _x ) then {
-                        _teleporters = _teleporters - [_x];
-                    };
-                };
+                _teleporters = _teleporters - [_x, objNull];
                 // [GVAR(teleportIDs), _id, _teleporters] call CBA_fnc_hashSet;
                 GVAR(teleportIDs) set [_id, _teleporters];
             };

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -108,6 +108,23 @@
             <Russian>Телепортам требуются одинаковые ID для синхронизации. Можно использовать один и тот же ID только в 2-х аномалиях!</Russian>
             <Polish>Teleportery potrzebują tego samego ID, by działać. Tylko dwie anomalie mogą mieć to samo ID!</Polish>
         </Key>
+        </Key>
+        <Key ID="STR_anomaly_teleport_onEnter_desc">
+            <Original>Runs this code when a unit enters into this portal. Params: [_enterTrigger, _exitTrigger, _unit].<br/>The code is ran on the server only, and before the player is teleported.</Original>
+            <English>Runs this code when a unit enters into this portal. Params: [_enterTrigger, _exitTrigger, _unit].<br/>The code is ran on the server only, and before the player is teleported.</English>
+            <!-- TODO: Add translations -->
+            <!-- <German></German>
+            <Russian></Russian>
+            <Polish></Polish> -->
+        </Key>
+        <Key ID="STR_anomaly_teleport_onExit_desc">
+            <Original>Runs this code when a unit exits from this portal. Params: [_enterTrigger, _exitTrigger, _unit].<br/>The code is ran on the server only, and after the player is teleported.</Original>
+            <English>Runs this code when a unit exits from this portal. Params: [_enterTrigger, _exitTrigger, _unit].<br/>The code is ran on the server only, and after the player is teleported.</English>
+            <!-- TODO: Add translations -->
+            <!-- <German></German>
+            <Russian></Russian>
+            <Polish></Polish> -->
+        </Key>
         <Key ID="STR_anomaly_teleport_desc">
             <Original>Spawn a teleport anomaly at module location</Original>
             <English>Spawn a teleport anomaly at module location</English>


### PR DESCRIPTION
This is still being tested, but I am creating this now so you can look at it today. I won't be back on to finish this until tomorrow (I work graveyard shift).

Multiple Teleporter Support:
* Removed checks for only 2 teleporters.
* Exit teleporter is chosen randomly `exit = random (teleporters - enterTeleporter)`
* Updated deleteAnomalies function

OnEnter and OnExit Code Hooks:
* The teleport module's `Arguments` moved to `Attributes` and `onEnterCode` and `onExitCode` attributes added
* Added `_onEnterCode` and `_onExitCode` params to `createTeleport` function. Module support also added.
* `onEnterCode` and `onExitCode` support added to activateTeleport.