### PR TITLE
Improve effect sync for most anomalies, Fix electra vehicle damage, Refactor code

### DIFF
--- a/addons/main/XEH_preInit.sqf
+++ b/addons/main/XEH_preInit.sqf
@@ -33,7 +33,7 @@ GVAR(medicalSystemMap) set ["ace_medical", createHashMapFromArray [
     ["burner", [[0.9, 10], ["head", "body", "hand_l", "hand_r", "leg_l", "leg_r"], "burn"]],
     ["comet", [[0.9, 10], ["head", "body"], "burn"]],
     ["electra", [[1, 10], ["head", "body"], "stab"]],
-    ["fog", [[0.05, 0.2], ["body"], "punch"]],
+    ["fog", [[0.2, 0.2], ["body"], "punch"]],
     ["fruitpunch", [[0.2, 0.333], ["leg_l", "leg_r"], "stab"]],
     ["springboard", [[1.5, 10], ["leg_l", "leg_r"], "stab"]],
     ["psydischarge", [[0.9, 0.9], ["head", "body", "hand_l", "hand_r", "leg_l", "leg_r"], "backblast"]]]

--- a/addons/main/XEH_preInit.sqf
+++ b/addons/main/XEH_preInit.sqf
@@ -100,10 +100,7 @@ if (hasInterface) then {
         deleteVehicle (_trg getVariable [QGVAR(soundIdleLocal), objNull]);
     }] call CBA_fnc_addEventHandler;
 
-    [QGVAR(fruitPunchEffect), {
-        if (isNull _this) exitWith {};
-        [_this, "active"] call FUNC(fruitPunchEffect);
-    }] call CBA_fnc_addEventHandler;
+    #include "anomalyFXEvents.inc.sqf"
 };
 
 [QGVAR(createAnomaly), {

--- a/addons/main/anomalyFXEvents.inc.sqf
+++ b/addons/main/anomalyFXEvents.inc.sqf
@@ -1,0 +1,139 @@
+[QGVAR(fruitPunchEffect), {
+    params ["_trg"];
+    if (isNull _trg) exitWith {};
+    private _proxy = _trg getVariable QGVAR(sound);
+    _proxy say3D (selectRandom ["bfuzz_hit","buzz_hit"]);
+    private _source = "#particlesource" createVehicleLocal getPos _trg;
+    _source setPosASL (getPosASL _trg);
+
+    [_source, "active"] call FUNC(fruitPunchEffect);
+    [{
+        deleteVehicle _this;
+    }, _source, 0.33] call CBA_fnc_waitAndExecute;
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(burnerEffect), {
+    params ["_trg"];
+    if (isNull _trg) exitWith {};
+    private _proxy = _trg getVariable QGVAR(sound);
+    _proxy say3D "fire2";
+
+    private _pos = getPos _trg;
+    private _source = "#particlesource" createVehicleLocal getPos _trg;
+    _source setPosASL (getPosASL _trg);
+    private _source2 = "#particlesource" createVehicleLocal [((_pos select 0) - 2 + (random 2)), ((_pos select 1) - 2 + (random 2)), _pos select 2];
+
+    [_source, "active"] call FUNC(burnerEffect);
+    [_source2, "active"] call FUNC(burnerEffect);
+
+    private _light = "#lightpoint" createVehicleLocal (getPos _proxy);
+    _light setLightBrightness 2;
+    _light setLightAmbient [1, 0.6, 0.6];
+    _light setLightColor [1, 0.6, 0.6];
+    _light setLightUseFlare true;
+    _light setLightFlareSize 12;
+    _light setLightFlareMaxDistance 100;
+    _light setLightDayLight true;
+
+    [{
+        {
+            deleteVehicle _x;
+        } forEach _this;
+    }, [_source, _source2, _light], 5] call CBA_fnc_waitAndExecute;
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(springboardEffect), {
+    params ["_trg"];
+    if (isNull _trg) exitWith {};
+    private _proxy = _trg getVariable QGVAR(sound);
+    _proxy say3D format ["gravi_blowout%1", (floor random 6) + 1];
+
+    [{
+        params ["_trg"];
+        private _source = "#particlesource" createVehicleLocal getPos _trg;
+        _source setPosASL (getPosASL _trg);
+        [_source, "active"] call FUNC(springboardEffect);
+        [{
+            deleteVehicle _this;
+        }, _source, 1] call CBA_fnc_waitAndExecute;
+    }, _this, 0.25] call CBA_fnc_waitAndExecute;
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(electraEffect), {
+    params ["_trg", "_list"];
+    if (isNull _trg) exitWith {};
+    private _proxy = _trg getVariable QGVAR(sound);
+    _proxy say3D format ["electra_blast%1", (floor random 2) + 1];
+
+    private _light = "#lightpoint" createVehicleLocal (getPos (_trg getVariable QGVAR(sound)));
+    _light setLightBrightness 10;
+    _light setLightAmbient [0.6, 0.6, 1];
+    _light setLightColor [0.6, 0.6, 1];
+    _light setLightUseFlare true;
+    _light setLightFlareSize 100;
+    _light setLightFlareMaxDistance 100;
+    _light setLightDayLight true;
+    [{
+        _this setLightBrightness 0;
+    }, _light, 0.1] call CBA_fnc_waitAndExecute;
+    [{
+        _this setLightBrightness 10;
+    }, _light, 0.2] call CBA_fnc_waitAndExecute;
+    [{
+        _this setLightBrightness 0;
+    }, _light, 0.4] call CBA_fnc_waitAndExecute;
+    [{
+        _this setLightBrightness 10;
+    }, _light, 1.6] call CBA_fnc_waitAndExecute;
+    [{
+        _this setLightBrightness 0;
+    }, _light, 1.7] call CBA_fnc_waitAndExecute;
+    [{
+        _this setLightBrightness 10;
+    }, _light, 1.8] call CBA_fnc_waitAndExecute;
+    [{
+        deleteVehicle _this;
+    }, _light, 2] call CBA_fnc_waitAndExecute;
+
+    private _plr = ([] call CBA_fnc_currentUnit);
+    if (_plr in _list) then {
+        addCamShake [15, 3, 25];
+    };
+
+    [{
+        params ["_plr", "_trg"];
+        private _source = _trg getVariable [QGVAR(particleSource), objNull];
+        if !(isNull _source) then {
+            deleteVehicle _source;
+            [{
+                !(_this getVariable [QGVAR(cooldown), false])
+            }, {
+                if (isNull _this) exitWith {};
+                if (([] call CBA_fnc_currentUnit) distance _this < GVAR(idleDistance)) then {
+                    private _source = "#particlesource" createVehicleLocal getPos _this;
+                    _source setPosASL (getPosASL _this);
+                    [_source, "idle"] call FUNC(electraEffect);
+                    _this setVariable [QGVAR(particleSource), _source];
+                };
+            }, _trg] call CBA_fnc_waitUntilAndExecute;
+        };
+    }, [_plr, _trg], 2] call CBA_fnc_waitAndExecute;
+}] call CBA_fnc_addEventHandler;
+
+[QGVAR(meatgrinderEffect), {
+    params ["_trg"];
+    if (isNull _trg) exitWith {};
+    private _proxy = _trg getVariable QGVAR(sound);
+    _proxy say3D "anomaly_mincer_blowout";
+
+    [{
+        params ["_trg"];
+        if (isNull _trg) exitWith {};
+        private _source = "#particlesource" createVehicleLocal getPos _trg;
+        _source setPosASL (getPosASL _trg);
+        [_source, "active"] call FUNC(springboardEffect);
+        [{
+            deleteVehicle _this;
+        }, _source, 1] call CBA_fnc_waitAndExecute;
+    }, [_trg], MEATGRINDER_MIN_COOL_DOWN] call CBA_fnc_waitAndExecute;
+}] call CBA_fnc_addEventHandler;

--- a/addons/main/functions/anomalies/fn_activateBurner.sqf
+++ b/addons/main/functions/anomalies/fn_activateBurner.sqf
@@ -44,9 +44,9 @@ private _men = nearestObjects [getPos _trg,  ["Man","landvehicle","air"], 5] sel
                 _curDam = 0;
             };
             if (_curDam >= 1) then {
-                _x setDamage 1;
+                _x setDamage [1, true, _x, _x];
             } else {
-                [QGVAR(setHitPointDamage), [_x, ["HitEngine", (_curDam + 0.15)]], _x] call CBA_fnc_targetEvent;
+                [QGVAR(setHitPointDamage), [_x, ["HitEngine", _curDam + 0.15, false]], _x] call CBA_fnc_targetEvent;
                 if !(_x isKindOf "tank") then {
                     [QGVAR(setHit), [_x, ["wheel_1_1_steering", 1]], _x] call CBA_fnc_targetEvent;
                     [QGVAR(setHit), [_x, ["wheel_1_2_steering", 1]], _x] call CBA_fnc_targetEvent;
@@ -61,7 +61,7 @@ private _men = nearestObjects [getPos _trg,  ["Man","landvehicle","air"], 5] sel
         };
         [QGVAR(burnerOnDamage), [_x, _trg]] call CBA_fnc_localEvent;
     } else {
-        if !(_x isKindOf "landvehicle" || _x isKindOf "air") then {
+        if !(_x isKindOf "LandVehicle" || _x isKindOf "Air") then {
             [QGVAR(minceCorpse), [_x]] call CBA_fnc_globalEvent;
         };
     };

--- a/addons/main/functions/anomalies/fn_activateBurner.sqf
+++ b/addons/main/functions/anomalies/fn_activateBurner.sqf
@@ -15,90 +15,58 @@
     Author:
     diwako 2017-12-13
 */
-params[["_trg",objNull],["_list",[]]];
+params[["_trg",objNull], ["_list",[]]];
+if (isNull _trg || !isServer || _trg getVariable [QGVAR(anomalyType),""] != "burner") exitWith {};
 
-if (isNull _trg) exitWith {};
-if (_trg getVariable [QGVAR(anomalyType),""] != "burner") exitWith {};
+_trg setVariable [QGVAR(cooldown), true, true];
 
-private _proxy = _trg getVariable QGVAR(sound);
-_proxy say3D "fire2";
+private _men = nearestObjects [getPos _trg,  ["Man","landvehicle","air"], 5] select {!(_x getVariable ["anomaly_ignore", false])};
+{
+    if !(_x isKindOf "Man" || _x isKindOf "landvehicle" || _x isKindOf "air") then {
+        deleteVehicle _x;
+    };
+} forEach _list;
 
-if (hasInterface) then {
-    private _pos = position _trg;
-    private _source = "#particlesource" createVehicleLocal getPos _trg;
-    _source setPosASL (getPosASL _trg);
-    private _source2 = "#particlesource" createVehicleLocal [((_pos select 0) - 2 + (random 2)), ((_pos select 1) - 2 + (random 2)), _pos select 2];
+[QGVAR(burnerEffect), [_trg]] call CBA_fnc_globalEvent;
 
-    [_source, "active"] call FUNC(burnerEffect);
-    [_source2, "active"] call FUNC(burnerEffect);
-
-    private _light = "#lightpoint" createVehicleLocal (getPos _proxy);
-    _light setLightBrightness 2;
-    _light setLightAmbient [1, 0.6, 0.6];
-    _light setLightColor [1, 0.6, 0.6];
-    _light setLightUseFlare true;
-    _light setLightFlareSize 12;
-    _light setLightFlareMaxDistance 100;
-    _light setLightDayLight true;
-
-    [{
-        {
-            deleteVehicle _x;
-        } forEach _this;
-    }, [_source, _source2, _light], 5] call CBA_fnc_waitAndExecute;
-};
-
-if (isServer) then {
-    _trg setVariable [QGVAR(cooldown), true, true];
-    private _men = nearestObjects [getPos _trg,  ["Man","landvehicle","air"], 5] select {!(_x getVariable ["anomaly_ignore", false])};
-    {
-        if !(_x isKindOf "Man" || _x isKindOf "landvehicle" || _x isKindOf "air") then {
-            deleteVehicle _x;
-        };
-    } forEach _list;
-    {
-        if (alive _x) then {
-            if (_x isKindOf "Man") then {
-                if !(isNil "ace_fire_fnc_burn") then {
-                    [_x, 4] call ace_fire_fnc_burn;
-                };
-                if (isPlayer _x) then {
-                    ["burner", _x] call FUNC(addUnitDamage);
-                } else {
-                    [{
-                        ["burner", _this] call FUNC(addUnitDamage);
-                    }, _x, 0.5] call CBA_fnc_waitAndExecute;
-                };
-            } else {
-                private _curDam = _x getHitPointDamage "HitEngine";
-                if (isNil "_curDam") then {
-                    _curDam = 0;
-                };
-                if (_curDam >= 1) then {
-                    _x setDamage 1;
-                } else {
-                    [QGVAR(setHitPointDamage), [_x, ["HitEngine", (_curDam + 0.15)]], _x] call CBA_fnc_targetEvent;
-                    if !(_x isKindOf "tank") then {
-                        [QGVAR(setHit), [_x, ["wheel_1_1_steering", 1]], _x] call CBA_fnc_targetEvent;
-                        [QGVAR(setHit), [_x, ["wheel_1_2_steering", 1]], _x] call CBA_fnc_targetEvent;
-                        [QGVAR(setHit), [_x, ["wheel_1_3_steering", 1]], _x] call CBA_fnc_targetEvent;
-                        [QGVAR(setHit), [_x, ["wheel_1_4_steering", 1]], _x] call CBA_fnc_targetEvent;
-                        [QGVAR(setHit), [_x, ["wheel_2_1_steering", 1]], _x] call CBA_fnc_targetEvent;
-                        [QGVAR(setHit), [_x, ["wheel_2_2_steering", 1]], _x] call CBA_fnc_targetEvent;
-                        [QGVAR(setHit), [_x, ["wheel_2_3_steering", 1]], _x] call CBA_fnc_targetEvent;
-                        [QGVAR(setHit), [_x, ["wheel_2_4_steering", 1]], _x] call CBA_fnc_targetEvent;
-                    };
-                };
+{
+    if (alive _x) then {
+        if (_x isKindOf "Man") then {
+            if !(isNil "ace_fire_fnc_burn") then {
+                [_x, 4] call ace_fire_fnc_burn;
             };
-            [QGVAR(burnerOnDamage), [_x, _trg]] call CBA_fnc_localEvent;
+            [{
+                ["burner", _this] call FUNC(addUnitDamage);
+            }, _x, [0.5, 0] select (isPlayer _x)] call CBA_fnc_waitAndExecute;
         } else {
-            if !(_x isKindOf "landvehicle" || _x isKindOf "air") then {
-                [QGVAR(minceCorpse), [_x]] call CBA_fnc_globalEvent;
+            private _curDam = _x getHitPointDamage "HitEngine";
+            if (isNil "_curDam") then {
+                _curDam = 0;
+            };
+            if (_curDam >= 1) then {
+                _x setDamage 1;
+            } else {
+                [QGVAR(setHitPointDamage), [_x, ["HitEngine", (_curDam + 0.15)]], _x] call CBA_fnc_targetEvent;
+                if !(_x isKindOf "tank") then {
+                    [QGVAR(setHit), [_x, ["wheel_1_1_steering", 1]], _x] call CBA_fnc_targetEvent;
+                    [QGVAR(setHit), [_x, ["wheel_1_2_steering", 1]], _x] call CBA_fnc_targetEvent;
+                    [QGVAR(setHit), [_x, ["wheel_1_3_steering", 1]], _x] call CBA_fnc_targetEvent;
+                    [QGVAR(setHit), [_x, ["wheel_1_4_steering", 1]], _x] call CBA_fnc_targetEvent;
+                    [QGVAR(setHit), [_x, ["wheel_2_1_steering", 1]], _x] call CBA_fnc_targetEvent;
+                    [QGVAR(setHit), [_x, ["wheel_2_2_steering", 1]], _x] call CBA_fnc_targetEvent;
+                    [QGVAR(setHit), [_x, ["wheel_2_3_steering", 1]], _x] call CBA_fnc_targetEvent;
+                    [QGVAR(setHit), [_x, ["wheel_2_4_steering", 1]], _x] call CBA_fnc_targetEvent;
+                };
             };
         };
-    } forEach _men;
+        [QGVAR(burnerOnDamage), [_x, _trg]] call CBA_fnc_localEvent;
+    } else {
+        if !(_x isKindOf "landvehicle" || _x isKindOf "air") then {
+            [QGVAR(minceCorpse), [_x]] call CBA_fnc_globalEvent;
+        };
+    };
+} forEach _men;
 
-    [{
-        _this setVariable [QGVAR(cooldown), false, true];
-    }, _trg, GVAR(anomalySettingBurnerCooldownMin) + random GVAR(anomalySettingBurnerCooldownRand)] call CBA_fnc_waitAndExecute;
-};
+[{
+    _this setVariable [QGVAR(cooldown), false, true];
+}, _trg, GVAR(anomalySettingBurnerCooldownMin) + random GVAR(anomalySettingBurnerCooldownRand)] call CBA_fnc_waitAndExecute;

--- a/addons/main/functions/anomalies/fn_activateComet.sqf
+++ b/addons/main/functions/anomalies/fn_activateComet.sqf
@@ -29,22 +29,18 @@ _trg setVariable [QGVAR(cooldown), true];
         if !(isNil "ace_fire_fnc_burn") then {
             [_x, 4] call ace_fire_fnc_burn;
         };
-        if (isPlayer _x) then {
-            ["comet", _x] call FUNC(addUnitDamage);
-        } else {
-            [{
-                ["comet", _this] call FUNC(addUnitDamage);
-            }, _x, 0.5] call CBA_fnc_waitAndExecute;
-        };
+        [{
+            ["comet", _this] call FUNC(addUnitDamage);
+        }, _x, [0.5, 0] select (isPlayer _x)] call CBA_fnc_waitAndExecute;
     } else {
         private _curDam = _x getHitPointDamage "HitEngine";
         if (isNil "_curDam") then {
             _curDam = 0;
         };
         if (_curDam >= 1) then {
-            _x setDamage 1;
+            _x setDamage [1, true, _x, _x];
         } else {
-            _x setHitPointDamage ["HitEngine", (_curDam + 0.15), true, _x, _x];
+            _x setHitPointDamage ["HitEngine", (_curDam + 0.15), false, _x, _x];
             if !(_x isKindOf "tank") then {
                 _x setHit ["wheel_1_1_steering", 1];
                 _x setHit ["wheel_1_2_steering", 1];

--- a/addons/main/functions/anomalies/fn_activateComet.sqf
+++ b/addons/main/functions/anomalies/fn_activateComet.sqf
@@ -16,9 +16,8 @@
     diwako 2024-10-19
 */
 params[["_trg",objNull], ["_list",[]]];
+if (isNull _trg || _trg getVariable [QGVAR(anomalyType),""] != "comet") exitWith {};
 
-if (isNull _trg) exitWith {};
-if (_trg getVariable [QGVAR(anomalyType),""] != "comet") exitWith {};
 private _local = _list select {local _x && {!(_x getVariable ["anomaly_ignore", false])}};
 
 // no need to do anything here, nothing local to handle

--- a/addons/main/functions/anomalies/fn_activateElectra.sqf
+++ b/addons/main/functions/anomalies/fn_activateElectra.sqf
@@ -30,7 +30,7 @@ if (isNull _trg || !isServer || _trg getVariable [QGVAR(anomalyType),""] != "ele
         if (_x isKindOf "landvehicle" || _x isKindOf "air") then {
             // switch of the engine
             private _curDam = _x getHitPointDamage "HitEngine";
-            [QGVAR(setHitPointDamage), [_x, ["HitEngine", 1, true, _x, _x]], _x] call CBA_fnc_targetEvent;
+            [QGVAR(setHitPointDamage), [_x, ["HitEngine", 1, false, _x, _x]], _x] call CBA_fnc_targetEvent;
             private _curDam2 = _x getHitPointDamage "HitHull";
             [QGVAR(setHitPointDamage), [_x, ["HitHull", _curDam2 + 0.1, true, _x, _x]], _x] call CBA_fnc_targetEvent;
             [{

--- a/addons/main/functions/anomalies/fn_activateElectra.sqf
+++ b/addons/main/functions/anomalies/fn_activateElectra.sqf
@@ -15,134 +15,54 @@
     Author:
     diwako 2017-12-11
 */
-params[["_trg",objNull],["_list",[]]];
+params[["_trg",objNull], ["_list",[]]];
+if (isNull _trg || !isServer || _trg getVariable [QGVAR(anomalyType),""] != "electra") exitWith {};
 
-if (isNull _trg) exitWith {};
-if (_trg getVariable [QGVAR(anomalyType),""] != "electra") exitWith {};
+[QGVAR(electraEffect), [_trg, _list]] call CBA_fnc_globalEvent;
 
-if (isServer) then {
-    private _proxy = _trg getVariable QGVAR(sound);
-    _sound = ("electra_blast" + str ( (floor random 2) + 1 ));
-    [QGVAR(say3D), [_proxy, _sound]] call CBA_fnc_globalEvent;
-
-    _men = (nearestObjects [getPos _trg,  ["Man","landvehicle","air"], 5]) select {!(_x getVariable ["anomaly_ignore", false])};
-    {
-        if (!(_x isKindOf "Man" || _x isKindOf "landvehicle" || _x isKindOf "air")) then {
-            deleteVehicle _x;
-        };
-    } forEach _list;
-    {
-        if (alive _x) then {
-            if (_x isKindOf "landvehicle" || _x isKindOf "air") then {
-                // switch of the engine
-                private _curDam = 0;
-                if (_x isKindOf "landvehicle" ) then {
-                    _curDam = _x getHit (getText(configOf _x >> "HitPoints" >> "HitEngine" >> "name"));
-                    [QGVAR(setHitPointDamage), [_x, ["HitEngine", 1, true, _x, _x]], _x] call CBA_fnc_targetEvent;
-                } else {
-                    _curDam = _x getHitPointDamage "HitEngine";
-                    [QGVAR(setHitPointDamage), [_x, ["HitEngine", 1, true, _x, _x]], _x] call CBA_fnc_targetEvent;
-                };
-                private _curDam2 = _x getHitPointDamage "HitHull";
-                [QGVAR(setHitPointDamage), [_x, ["HitHull", (_curDam2 + 0.1)]], _x] call CBA_fnc_targetEvent;
-                [{
-                    private ["_veh", "_curDam"];
-                    if (_veh isKindOf "landvehicle" ) then {
-                        [QGVAR(setHitPointDamage), [_veh, ["HitEngine", (_curDam + 0.25)], true, _x, _x], _x] call CBA_fnc_targetEvent;
-                    } else {
-
-                        [QGVAR(setHitPointDamage), [_veh, ["HitEngine", (_curDam + 0.25), true, _x, _x]], _veh] call CBA_fnc_targetEvent;
-                    };
-                }, [_x, _curDam], 5] call CBA_fnc_waitAndExecute;
+{
+    if !(_x isKindOf "Man" || _x isKindOf "landvehicle" || _x isKindOf "air") then {
+        deleteVehicle _x;
+    };
+} forEach _list;
+{
+    if (alive _x) then {
+        if (_x isKindOf "landvehicle" || _x isKindOf "air") then {
+            // switch of the engine
+            private _curDam = 0;
+            if (_x isKindOf "landvehicle" ) then {
+                _curDam = _x getHit (getText(configOf _x >> "HitPoints" >> "HitEngine" >> "name"));
+                [QGVAR(setHitPointDamage), [_x, ["HitEngine", 1, true, _x, _x]], _x] call CBA_fnc_targetEvent;
             } else {
-                // [_x, getPos _trg, 2, 2] remoteExec [QFUNC(suckToLocation),_x];
-                [{
-                    ["electra", _this] call FUNC(addUnitDamage);
-                }, _x, 2] call CBA_fnc_waitAndExecute;
+                _curDam = _x getHitPointDamage "HitEngine";
+                [QGVAR(setHitPointDamage), [_x, ["HitEngine", 1, true, _x, _x]], _x] call CBA_fnc_targetEvent;
             };
-            [QGVAR(electraOnDamage), [_x, _trg]] call CBA_fnc_localEvent;
-        } else {
-            if (!(_x isKindOf "landvehicle" || _x isKindOf "air") ) then {
-                [QGVAR(minceCorpse), [_x]] call CBA_fnc_globalEvent;
-            };
-        };
-    } forEach (_men select {!isPlayer _x});
-
-    _trg setVariable [QGVAR(cooldown), true, true];
-    [{
-        _this setVariable [QGVAR(cooldown), false, true];
-    }, _trg, GVAR(anomalySettingBurnerCooldownMin) + random GVAR(anomalySettingBurnerCooldownRand)] call CBA_fnc_waitAndExecute;
-};
-
-if (hasInterface) then {
-    private _light = "#lightpoint" createVehicleLocal (getPos (_trg getVariable QGVAR(sound)));
-    _light setLightBrightness 10;
-    _light setLightAmbient [0.6, 0.6, 1];
-    _light setLightColor [0.6, 0.6, 1];
-    _light setLightUseFlare true;
-    _light setLightFlareSize 100;
-    _light setLightFlareMaxDistance 100;
-    _light setLightDayLight true;
-    [{
-        _this setLightBrightness 0;
-    }, _light, 0.1] call CBA_fnc_waitAndExecute;
-    [{
-        _this setLightBrightness 10;
-    }, _light, 0.2] call CBA_fnc_waitAndExecute;
-    [{
-        _this setLightBrightness 0;
-    }, _light, 0.4] call CBA_fnc_waitAndExecute;
-    [{
-        _this setLightBrightness 10;
-    }, _light, 1.6] call CBA_fnc_waitAndExecute;
-    [{
-        _this setLightBrightness 0;
-    }, _light, 1.7] call CBA_fnc_waitAndExecute;
-    [{
-        _this setLightBrightness 10;
-    }, _light, 1.8] call CBA_fnc_waitAndExecute;
-    [{
-        deleteVehicle _this;
-    }, _light, 2] call CBA_fnc_waitAndExecute;
-
-    private _plr = ([] call CBA_fnc_currentUnit);
-    private _in = (_plr in _list );
-    if (_in) then {
-        // [_plr, getPos _trg, 2, 2] spawn FUNC(suckToLocation);
-        addCamShake [15, 3, 25];
-    };
-    private _veh = vehicle _plr;
-    if (_veh in _list && {_veh isKindOf "landvehicle" && {(driver _veh) isEqualTo _plr}}) then {
-        [QGVAR(setHitPointDamage), [_veh, ["HitEngine", 1, true, _x, _x]], _veh] call CBA_fnc_targetEvent;
-        private _curDam2 = _veh getHitPointDamage "HitHull";
-        [QGVAR(setHitPointDamage), [_veh, ["HitHull", (_curDam2 + 0.1), true, _x, _x]], _veh] call CBA_fnc_targetEvent;
-
-        [{
-            private _curDam = _this getHit (getText(configOf _this >> "HitPoints" >> "HitEngine" >> "name"));
-            [QGVAR(setHitPointDamage), [_this, ["HitEngine", (_curDam + 0.25), true, _x, _x]], _this] call CBA_fnc_targetEvent;
-        }, _veh, 5] call CBA_fnc_waitAndExecute;
-    };
-
-    [{
-        params ["_plr", "_in", "_trg"];
-        if (_in && !(_plr getVariable ["anomaly_ignore", false])) then {
-            ["electra", _plr] call FUNC(addUnitDamage);
-        };
-
-        private _source = _trg getVariable [QGVAR(particleSource), objNull];
-        if !(isNull _source) then {
-            deleteVehicle _source;
+            private _curDam2 = _x getHitPointDamage "HitHull";
+            [QGVAR(setHitPointDamage), [_x, ["HitHull", (_curDam2 + 0.1)]], _x] call CBA_fnc_targetEvent;
             [{
-                !(_this getVariable [QGVAR(cooldown), false])
-            }, {
-                if (isNull _this) exitWith {};
-                if (([] call CBA_fnc_currentUnit) distance _this < GVAR(idleDistance)) then {
-                    private _source = "#particlesource" createVehicleLocal getPos _this;
-                    _source setPosASL (getPosASL _this);
-                    [_source, "idle"] call FUNC(electraEffect);
-                    _this setVariable [QGVAR(particleSource), _source];
+                private ["_veh", "_curDam"];
+                if (_veh isKindOf "landvehicle" ) then {
+                    [QGVAR(setHitPointDamage), [_veh, ["HitEngine", (_curDam + 0.25)], true, _x, _x], _x] call CBA_fnc_targetEvent;
+                } else {
+
+                    [QGVAR(setHitPointDamage), [_veh, ["HitEngine", (_curDam + 0.25), true, _x, _x]], _veh] call CBA_fnc_targetEvent;
                 };
-            }, _trg] call CBA_fnc_waitUntilAndExecute;
+            }, [_x, _curDam], 5] call CBA_fnc_waitAndExecute;
+        } else {
+            // [_x, getPos _trg, 2, 2] remoteExec [QFUNC(suckToLocation),_x];
+            [{
+                ["electra", _this] call FUNC(addUnitDamage);
+            }, _x, 1 + (random 1)] call CBA_fnc_waitAndExecute;
         };
-    }, [_plr, _in, _trg], 2] call CBA_fnc_waitAndExecute;
-};
+        [QGVAR(electraOnDamage), [_x, _trg]] call CBA_fnc_localEvent;
+    } else {
+        if (!(_x isKindOf "landvehicle" || _x isKindOf "air") ) then {
+            [QGVAR(minceCorpse), [_x]] call CBA_fnc_globalEvent;
+        };
+    };
+} forEach ((nearestObjects [getPos _trg,  ["Man", "landvehicle", "air"], 5]) select {!(_x getVariable ["anomaly_ignore", false])});
+
+_trg setVariable [QGVAR(cooldown), true, true];
+[{
+    _this setVariable [QGVAR(cooldown), false, true];
+}, _trg, GVAR(anomalySettingBurnerCooldownMin) + random GVAR(anomalySettingBurnerCooldownRand)] call CBA_fnc_waitAndExecute;

--- a/addons/main/functions/anomalies/fn_activateElectra.sqf
+++ b/addons/main/functions/anomalies/fn_activateElectra.sqf
@@ -29,24 +29,13 @@ if (isNull _trg || !isServer || _trg getVariable [QGVAR(anomalyType),""] != "ele
     if (alive _x) then {
         if (_x isKindOf "landvehicle" || _x isKindOf "air") then {
             // switch of the engine
-            private _curDam = 0;
-            if (_x isKindOf "landvehicle" ) then {
-                _curDam = _x getHit (getText(configOf _x >> "HitPoints" >> "HitEngine" >> "name"));
-                [QGVAR(setHitPointDamage), [_x, ["HitEngine", 1, true, _x, _x]], _x] call CBA_fnc_targetEvent;
-            } else {
-                _curDam = _x getHitPointDamage "HitEngine";
-                [QGVAR(setHitPointDamage), [_x, ["HitEngine", 1, true, _x, _x]], _x] call CBA_fnc_targetEvent;
-            };
+            private _curDam = _x getHitPointDamage "HitEngine";
+            [QGVAR(setHitPointDamage), [_x, ["HitEngine", 1, true, _x, _x]], _x] call CBA_fnc_targetEvent;
             private _curDam2 = _x getHitPointDamage "HitHull";
-            [QGVAR(setHitPointDamage), [_x, ["HitHull", (_curDam2 + 0.1)]], _x] call CBA_fnc_targetEvent;
+            [QGVAR(setHitPointDamage), [_x, ["HitHull", _curDam2 + 0.1, true, _x, _x]], _x] call CBA_fnc_targetEvent;
             [{
-                private ["_veh", "_curDam"];
-                if (_veh isKindOf "landvehicle" ) then {
-                    [QGVAR(setHitPointDamage), [_veh, ["HitEngine", (_curDam + 0.25)], true, _x, _x], _x] call CBA_fnc_targetEvent;
-                } else {
-
-                    [QGVAR(setHitPointDamage), [_veh, ["HitEngine", (_curDam + 0.25), true, _x, _x]], _veh] call CBA_fnc_targetEvent;
-                };
+                params ["_veh", "_curDam"];
+                [QGVAR(setHitPointDamage), [_veh, ["HitEngine", _curDam + 0.25, true, _veh, _veh]], _veh] call CBA_fnc_targetEvent;
             }, [_x, _curDam], 5] call CBA_fnc_waitAndExecute;
         } else {
             // [_x, getPos _trg, 2, 2] remoteExec [QFUNC(suckToLocation),_x];

--- a/addons/main/functions/anomalies/fn_activateFog.sqf
+++ b/addons/main/functions/anomalies/fn_activateFog.sqf
@@ -25,7 +25,7 @@ private _units = _list select {local _x && {!(_x getVariable ["anomaly_ignore", 
             _units pushBack _x
         };
     } forEach crew _x;
-} forEach (_list select {_x isKindOf "LandVehicle" && {!(_x getVariable ["anomaly_ignore", false])}});
+} forEach (_list select {(_x isKindOf "LandVehicle" || _x isKindOf "Air") && {!(_x getVariable ["anomaly_ignore", false])}});
 
 {
     if !(toUpper(goggles _x) in GVAR(gasMasks)) then {

--- a/addons/main/functions/anomalies/fn_activateFog.sqf
+++ b/addons/main/functions/anomalies/fn_activateFog.sqf
@@ -16,46 +16,50 @@
     diwako 2017-12-11
 */
 params[["_trg",objNull], ["_list",[]]];
+if (isNull _trg || _trg getVariable [QGVAR(anomalyType),""] != "fog") exitWith {};
 
-if (isNull _trg) exitWith {};
-if (_trg getVariable [QGVAR(anomalyType),""] != "fog") exitWith {};
+private _units = _list select {local _x && {!(_x getVariable ["anomaly_ignore", false]) && {_x isKindOf "Man"}}};
+{
+    {
+        if (local _x) then {
+            _units pushBack _x
+        };
+    } forEach crew _x;
+} forEach (_list select {_x isKindOf "LandVehicle" && {!(_x getVariable ["anomaly_ignore", false])}});
 
 {
-    if ((_x isKindOf "Man") && {local _x}) then {
-        if !(toUpper(goggles _x) in GVAR(gasMasks)) then {
-            if (isPlayer _x) then {
-                private _effect = [4];
-                if (isNil QGVAR(blurHandle)) then {
-                    private _name = "DynamicBlur";
-                    private _priority = 400;
+    if !(toUpper(goggles _x) in GVAR(gasMasks)) then {
+        if (isPlayer _x) then {
+            private _effect = [4];
+            if (isNil QGVAR(blurHandle)) then {
+                private _name = "DynamicBlur";
+                private _priority = 400;
+                GVAR(blurHandle) = ppEffectCreate [_name, _priority];
+                while {
+                    GVAR(blurHandle) < 0
+                } do {
+                    _priority = _priority + 1;
                     GVAR(blurHandle) = ppEffectCreate [_name, _priority];
-                    while {
-                        GVAR(blurHandle) < 0
-                    } do {
-                        _priority = _priority + 1;
-                        GVAR(blurHandle) = ppEffectCreate [_name, _priority];
-                    };
-                    GVAR(blurHandle) ppEffectEnable true;
                 };
-                GVAR(blurHandle) ppEffectAdjust _effect;
-                GVAR(blurHandle) ppEffectCommit 1;
-                [{
-                    GVAR(blurHandle) ppEffectAdjust [0];
-                    GVAR(blurHandle) ppEffectCommit 10;
-                }, nil, 1] call CBA_fnc_waitAndExecute;
+                GVAR(blurHandle) ppEffectEnable true;
             };
-            if ((cba_missiontime - 2.5) > (_x getVariable[QGVAR(cough), -1])) then {
-                // cough cough
-                [{
-                    params["_unit"];
-                    private _coughers = ["WoundedGuyA_02","WoundedGuyA_04","WoundedGuyA_05","WoundedGuyA_07","WoundedGuyA_08"];
-                    [QGVAR(say3D), [_unit, selectRandom _coughers]] call CBA_fnc_globalEvent;
-                }, [_x], (random 2)] call CBA_fnc_waitAndExecute;
-                _x setVariable[QGVAR(cough),cba_missiontime];
-            };
-            ["fog", _x] call FUNC(addUnitDamage);
-            [QGVAR(fogOnDamage), [_x, _trg]] call CBA_fnc_localEvent;
+            GVAR(blurHandle) ppEffectAdjust _effect;
+            GVAR(blurHandle) ppEffectCommit 1;
+            [{
+                GVAR(blurHandle) ppEffectAdjust [0];
+                GVAR(blurHandle) ppEffectCommit 10;
+            }, nil, 1] call CBA_fnc_waitAndExecute;
         };
+        if ((cba_missiontime - 2.5) > (_x getVariable[QGVAR(cough), -1])) then {
+            // cough cough
+            [{
+                params["_unit"];
+                private _coughers = ["WoundedGuyA_02","WoundedGuyA_04","WoundedGuyA_05","WoundedGuyA_07","WoundedGuyA_08"];
+                [QGVAR(say3D), [_unit, selectRandom _coughers]] call CBA_fnc_globalEvent;
+            }, [_x], (random 2)] call CBA_fnc_waitAndExecute;
+            _x setVariable[QGVAR(cough), cba_missiontime];
+        };
+        ["fog", _x] call FUNC(addUnitDamage);
+        [QGVAR(fogOnDamage), [_x, _trg]] call CBA_fnc_localEvent;
     };
-    false
-} count (_list select {!(_x getVariable ["anomaly_ignore", false])});
+} forEach _units;

--- a/addons/main/functions/anomalies/fn_activateFruitPunch.sqf
+++ b/addons/main/functions/anomalies/fn_activateFruitPunch.sqf
@@ -15,19 +15,12 @@
     Author:
     diwako 2018-06-10
 */
-if !(isServer) exitWith {};
-params [["_trg",objNull], ["_list",[]]];
+params [["_trg", objNull], ["_list",[]]];
+if (isNull _trg || !isServer || _trg getVariable [QGVAR(anomalyType),""] != "fruitpunch") exitWith {};
 
-if (isNull _trg) exitWith {};
-if (_trg getVariable [QGVAR(anomalyType),""] != "fruitpunch") exitWith {};
-
-private _proxy = _trg getVariable QGVAR(sound);
-[QGVAR(say3D), [_proxy, selectRandom ["bfuzz_hit","buzz_hit"]]] call CBA_fnc_globalEvent;
 _trg setVariable [QGVAR(cooldown), true];
 
-private _source = "#particlesource" createVehicle getPos _trg;
-_source setPosASL (getPosASL _trg);
-[QGVAR(fruitPunchEffect), _source] call CBA_fnc_globalEvent;
+[QGVAR(fruitPunchEffect), [_trg]] call CBA_fnc_globalEvent;
 {
     if (_x isKindOf "Man") then {
         ["fruitpunch", _x] call FUNC(addUnitDamage);
@@ -37,13 +30,8 @@ _source setPosASL (getPosASL _trg);
             deleteVehicle _x;
         };
     };
-    false
-} count (_list select {!(_x getVariable ["anomaly_ignore", false])});
+} forEach (_list select {!(_x getVariable ["anomaly_ignore", false])});
+
 [{
-    deleteVehicle _this;
-}, _source, 0.33] call CBA_fnc_waitAndExecute;
-[{
-    params ["_trg", "_source"];
-    deleteVehicle _source;
-    _trg setVariable [QGVAR(cooldown), false];
-}, [_trg, _source], 2] call CBA_fnc_waitAndExecute;
+    _this setVariable [QGVAR(cooldown), false];
+}, _trg, 2] call CBA_fnc_waitAndExecute;

--- a/addons/main/functions/anomalies/fn_activateMeatgrinder.sqf
+++ b/addons/main/functions/anomalies/fn_activateMeatgrinder.sqf
@@ -16,66 +16,52 @@
     diwako 2017-12-11
 */
 
-params[["_trg",objNull],["_list",[]]];
-
-if (isNull _trg) exitWith {};
-if (_trg getVariable [QGVAR(anomalyType),""] != "meatgrinder") exitWith {};
+params[["_trg",objNull], ["_list",[]]];
+if (isNull _trg || !isServer || _trg getVariable [QGVAR(anomalyType),""] != "meatgrinder") exitWith {};
 
 private _sucked = [];
-if (isServer) then {
-    _trg setVariable [QGVAR(cooldown), true, true];
-    _men = (nearestObjects [getPos _trg,  ["Man","landvehicle","air"], 5]) select {!(_x getVariable ["anomaly_ignore", false])};
-    private _proxy = _trg getVariable QGVAR(sound);
-    [QGVAR(say3D), [_proxy, "anomaly_mincer_blowout"]] call CBA_fnc_globalEvent;
-    {
-        if (!(_x isKindOf "Man" || _x isKindOf "landvehicle" || _x isKindOf "air")) then {
-            deleteVehicle _x;
-        };
-    } forEach _list;
-    {
-        if (alive _x) then {
-            if (_x isKindOf "landvehicle" || _x isKindOf "air") then {
-                if (getMass _x <= 10000) then {
-                    [QGVAR(suckToLocation), [_x, getPos _trg, 1, 5.8], _x] call CBA_fnc_targetEvent;
-                    _sucked pushBackUnique _x;
-                };
-            } else {
-                _sucked pushBackUnique _x;
-                [QGVAR(suckToLocation), [_x, getPos _trg, 2], _x] call CBA_fnc_targetEvent;
+_trg setVariable [QGVAR(cooldown), true, true];
+private _men = (nearestObjects [getPos _trg,  ["Man","landvehicle","air"], 5]) select {!(_x getVariable ["anomaly_ignore", false])};
+
+{
+    if (!(_x isKindOf "Man" || _x isKindOf "landvehicle" || _x isKindOf "air")) then {
+        deleteVehicle _x;
+    };
+} forEach _list;
+{
+    if (alive _x) then {
+        if (_x isKindOf "landvehicle" || _x isKindOf "air") then {
+            if (getMass _x <= 10000) then {
+                [QGVAR(suckToLocation), [_x, getPos _trg, 1, 5.8], _x] call CBA_fnc_targetEvent;
+                _sucked pushBack _x;
             };
         } else {
-            if (!(_x isKindOf "landvehicle") || _x isKindOf "air") then {
-                [QGVAR(minceCorpse), [_x]] call CBA_fnc_globalEvent;
-            };
+            _sucked pushBack _x;
+            [QGVAR(suckToLocation), [_x, getPos _trg, 2], _x] call CBA_fnc_targetEvent;
         };
-    } forEach _men;
-};
+    } else {
+        if (!(_x isKindOf "landvehicle") || _x isKindOf "air") then {
+            [QGVAR(minceCorpse), [_x]] call CBA_fnc_globalEvent;
+        };
+    };
+} forEach _men;
+
+[QGVAR(meatgrinderEffect), [_trg]] call CBA_fnc_globalEvent;
 
 [{
     params ["_trg", "_sucked"];
-    if (hasInterface) then {
-        private _source = "#particlesource" createVehicleLocal getPos _trg;
-        _source setPosASL (getPosASL _trg);
-        [_source, "active"] call FUNC(springboardEffect);
-        [{
-            deleteVehicle _this;
-        }, _source, 1] call CBA_fnc_waitAndExecute;
-    };
-
-    if (isServer) then {
-        {
-            if (_x isKindOf "Man") then {
-                // ace medical not needed, people trapped in this trap are dead
-                _x setDamage 1;
-                [QGVAR(minceCorpse), [_x]] call CBA_fnc_globalEvent;
-            } else {
-                private _curDam = _x getHitPointDamage "HitHull";
-                [QGVAR(setHitPointDamage), [_x, ["HitHull", (_curDam + 0.45), true, _x, _x]], _x] call CBA_fnc_targetEvent;
-            };
-            [QGVAR(meatgrinderOnDamage), [_x, _trg]] call CBA_fnc_localEvent;
-        } forEach _sucked;
-        [{
-            _this setVariable [QGVAR(cooldown), false, true];
-        }, _trg, anomalySettingMeatgrinderCooldownMin - MEATGRINDER_MIN_COOL_DOWN + random anomalySettingMeatgrinderCooldownRand] call CBA_fnc_waitAndExecute;
-    };
+    {
+        if (_x isKindOf "Man") then {
+            // ace medical not needed, people trapped in this trap are dead
+            _x setDamage 1;
+            [QGVAR(minceCorpse), [_x]] call CBA_fnc_globalEvent;
+        } else {
+            private _curDam = _x getHitPointDamage "HitHull";
+            [QGVAR(setHitPointDamage), [_x, ["HitHull", (_curDam + 0.45), true, _x, _x]], _x] call CBA_fnc_targetEvent;
+        };
+        [QGVAR(meatgrinderOnDamage), [_x, _trg]] call CBA_fnc_localEvent;
+    } forEach _sucked;
+    [{
+        _this setVariable [QGVAR(cooldown), false, true];
+    }, _trg, anomalySettingMeatgrinderCooldownMin - MEATGRINDER_MIN_COOL_DOWN + random anomalySettingMeatgrinderCooldownRand] call CBA_fnc_waitAndExecute;
 }, [_trg, _sucked], MEATGRINDER_MIN_COOL_DOWN] call CBA_fnc_waitAndExecute;

--- a/addons/main/functions/anomalies/fn_activateMeatgrinder.sqf
+++ b/addons/main/functions/anomalies/fn_activateMeatgrinder.sqf
@@ -19,18 +19,19 @@
 params[["_trg",objNull], ["_list",[]]];
 if (isNull _trg || !isServer || _trg getVariable [QGVAR(anomalyType),""] != "meatgrinder") exitWith {};
 
-private _sucked = [];
 _trg setVariable [QGVAR(cooldown), true, true];
-private _men = (nearestObjects [getPos _trg,  ["Man","landvehicle","air"], 5]) select {!(_x getVariable ["anomaly_ignore", false])};
 
 {
-    if (!(_x isKindOf "Man" || _x isKindOf "landvehicle" || _x isKindOf "air")) then {
+    if (!(_x isKindOf "Man" || _x isKindOf "LandVehicle" || _x isKindOf "Air")) then {
         deleteVehicle _x;
     };
 } forEach _list;
+
+private _men = (nearestObjects [getPos _trg,  ["Man", "LandVehicle" ,"Air"], 5]) select {!(_x getVariable ["anomaly_ignore", false])};
+private _sucked = [];
 {
     if (alive _x) then {
-        if (_x isKindOf "landvehicle" || _x isKindOf "air") then {
+        if (_x isKindOf "LandVehicle" || _x isKindOf "Air") then {
             if (getMass _x <= 10000) then {
                 [QGVAR(suckToLocation), [_x, getPos _trg, 1, 5.8], _x] call CBA_fnc_targetEvent;
                 _sucked pushBack _x;
@@ -40,7 +41,7 @@ private _men = (nearestObjects [getPos _trg,  ["Man","landvehicle","air"], 5]) s
             [QGVAR(suckToLocation), [_x, getPos _trg, 2], _x] call CBA_fnc_targetEvent;
         };
     } else {
-        if (!(_x isKindOf "landvehicle") || _x isKindOf "air") then {
+        if !(_x isKindOf "LandVehicle" || _x isKindOf "Air") then {
             [QGVAR(minceCorpse), [_x]] call CBA_fnc_globalEvent;
         };
     };
@@ -53,7 +54,7 @@ private _men = (nearestObjects [getPos _trg,  ["Man","landvehicle","air"], 5]) s
     {
         if (_x isKindOf "Man") then {
             // ace medical not needed, people trapped in this trap are dead
-            _x setDamage 1;
+            _x setDamage [1, true, _x, _x];
             [QGVAR(minceCorpse), [_x]] call CBA_fnc_globalEvent;
         } else {
             private _curDam = _x getHitPointDamage "HitHull";

--- a/addons/main/functions/anomalies/fn_activateSpringboard.sqf
+++ b/addons/main/functions/anomalies/fn_activateSpringboard.sqf
@@ -15,74 +15,59 @@
     Author:
     diwako 2017-12-11
 */
-params[["_trg",objNull],["_list",[]]];
+params[["_trg",objNull], ["_list",[]]];
+if (isNull _trg || !isServer || _trg getVariable [QGVAR(anomalyType),""] != "springboard") exitWith {};
 
-if (isNull _trg) exitWith {};
-if (_trg getVariable [QGVAR(anomalyType),""] != "springboard") exitWith {};
+_trg setVariable [QGVAR(cooldown), true, true];
 
-if (isServer) then {
-    _trg setVariable [QGVAR(cooldown), true, true];
-    private _proxy = _trg getVariable QGVAR(sound);
-    private _sound = ("gravi_blowout" + str ( (floor random 6) + 1 ));
-    [QGVAR(say3D), [_proxy, _sound]] call CBA_fnc_globalEvent;
-};
+[QGVAR(springboardEffect), [_trg]] call CBA_fnc_globalEvent;
 
 [{
     params[["_trg",objNull],["_list",[]]];
-    if (hasInterface) then {
-        private _source = "#particlesource" createVehicleLocal getPos _trg;
-        _source setPosASL (getPosASL _trg);
-        [_source, "active"] call FUNC(springboardEffect);
-        [{
-            deleteVehicle _this;
-        }, _source, 1] call CBA_fnc_waitAndExecute;
-    };
 
-    if (isServer) then {
-        private _men = (nearestObjects [getPos _trg,  ["Man","landvehicle","air"], 5]) select {!(_x getVariable ["anomaly_ignore", false])};
-        {
-            if (!(_x isKindOf "Man" || _x isKindOf "landvehicle" || _x isKindOf "air")) then {
-                deleteVehicle _x;
-            };
-        } forEach _list;
+    private _men = (nearestObjects [getPos _trg,  ["Man","landvehicle","air"], 5]) select {!(_x getVariable ["anomaly_ignore", false])};
+    {
+        if (!(_x isKindOf "Man" || _x isKindOf "landvehicle" || _x isKindOf "air")) then {
+            deleteVehicle _x;
+        };
+    } forEach _list;
 
-        {
-            if (alive _x) then {
-                private _pos1 = getPos _x;
-                private _pos2 = getPos _trg;
-                private _a = ((_pos1 select 0) - (_pos2 select 0));
-                private _b = ((_pos1 select 1) - (_pos2 select 1));
-                if !(isPlayer _x) then {
-                    if !(_x isKindOf "landvehicle"  || _x isKindOf "air") then {
-                        [{
-                            ["springboard", _this] call FUNC(addUnitDamage);
-                        }, _x, 0.5] call CBA_fnc_waitAndExecute;
-                    };
-                } else {
-                    ["springboard", _x] call FUNC(addUnitDamage);
+    {
+        if (alive _x) then {
+            private _pos1 = getPos _x;
+            private _pos2 = getPos _trg;
+            private _a = ((_pos1 select 0) - (_pos2 select 0));
+            private _b = ((_pos1 select 1) - (_pos2 select 1));
+            if !(isPlayer _x) then {
+                if !(_x isKindOf "landvehicle"  || _x isKindOf "air") then {
+                    [{
+                        ["springboard", _this] call FUNC(addUnitDamage);
+                    }, _x, 0.5] call CBA_fnc_waitAndExecute;
                 };
-                private _mult = 4;
-                if (_x isKindOf "landvehicle" || _x isKindOf "air") then {
-                    if (getMass _x <= 10000) then {
-                        _mult = _mult * 2;
-                        private _curDam = _x getHitPointDamage "HitHull";
-                        [QGVAR(setHitPointDamage), [_x, ["HitHull", (_curDam + 0.45), true, _x, _x]], _x] call CBA_fnc_targetEvent;
-                    } else {
-                        _mult = 1;
-                    };
-                };
-                // [_x, [_a*_mult, _b*_mult, _mult + (5 / (1 + (abs _a) + (abs _b)))]] remoteExec ["setVelocity", _x];
-                [QGVAR(setVelocity), [_x, [_a*_mult, _b*_mult, _mult + (5 / (1 + (abs _a) + (abs _b)))]], _x] call CBA_fnc_targetEvent;
-                [QGVAR(springboardOnDamage), [_x, _trg]] call CBA_fnc_localEvent;
             } else {
-                if !(_x isKindOf "landvehicle" || _x isKindOf "air") then {
-                    [QGVAR(minceCorpse), [_x]] call CBA_fnc_globalEvent;
+                ["springboard", _x] call FUNC(addUnitDamage);
+            };
+            private _mult = 4;
+            if (_x isKindOf "landvehicle" || _x isKindOf "air") then {
+                if (getMass _x <= 10000) then {
+                    _mult = _mult * 2;
+                    private _curDam = _x getHitPointDamage "HitHull";
+                    [QGVAR(setHitPointDamage), [_x, ["HitHull", (_curDam + 0.45), true, _x, _x]], _x] call CBA_fnc_targetEvent;
+                } else {
+                    _mult = 1;
                 };
             };
-        } forEach _men;
+            // [_x, [_a*_mult, _b*_mult, _mult + (5 / (1 + (abs _a) + (abs _b)))]] remoteExec ["setVelocity", _x];
+            [QGVAR(setVelocity), [_x, [_a*_mult, _b*_mult, _mult + (5 / (1 + (abs _a) + (abs _b)))]], _x] call CBA_fnc_targetEvent;
+            [QGVAR(springboardOnDamage), [_x, _trg]] call CBA_fnc_localEvent;
+        } else {
+            if !(_x isKindOf "landvehicle" || _x isKindOf "air") then {
+                [QGVAR(minceCorpse), [_x]] call CBA_fnc_globalEvent;
+            };
+        };
+    } forEach _men;
 
-        [{
-            _this setVariable [QGVAR(cooldown), false, true];
-        }, _trg, GVAR(anomalySettingSpringboardCooldownMin) - SPRINGBOARD_MIN_COOL_DOWN + random GVAR(anomalySettingSpringboardCooldownRand)] call CBA_fnc_waitAndExecute;
-    };
+    [{
+        _this setVariable [QGVAR(cooldown), false, true];
+    }, _trg, GVAR(anomalySettingSpringboardCooldownMin) - SPRINGBOARD_MIN_COOL_DOWN + random GVAR(anomalySettingSpringboardCooldownRand)] call CBA_fnc_waitAndExecute;
 }, _this, 0.25] call CBA_fnc_waitAndExecute;

--- a/addons/main/functions/anomalies/fn_activateSpringboard.sqf
+++ b/addons/main/functions/anomalies/fn_activateSpringboard.sqf
@@ -25,30 +25,21 @@ _trg setVariable [QGVAR(cooldown), true, true];
 [{
     params[["_trg",objNull],["_list",[]]];
 
-    private _men = (nearestObjects [getPos _trg,  ["Man","landvehicle","air"], 5]) select {!(_x getVariable ["anomaly_ignore", false])};
     {
-        if (!(_x isKindOf "Man" || _x isKindOf "landvehicle" || _x isKindOf "air")) then {
+        if (!(_x isKindOf "Man" || _x isKindOf "LandVehicle" || _x isKindOf "Air")) then {
             deleteVehicle _x;
         };
     } forEach _list;
 
+    private _men = (nearestObjects [getPos _trg,  ["Man", "LandVehicle" ,"Air"], 5]) select {!(_x getVariable ["anomaly_ignore", false])};
     {
         if (alive _x) then {
             private _pos1 = getPos _x;
             private _pos2 = getPos _trg;
             private _a = ((_pos1 select 0) - (_pos2 select 0));
             private _b = ((_pos1 select 1) - (_pos2 select 1));
-            if !(isPlayer _x) then {
-                if !(_x isKindOf "landvehicle"  || _x isKindOf "air") then {
-                    [{
-                        ["springboard", _this] call FUNC(addUnitDamage);
-                    }, _x, 0.5] call CBA_fnc_waitAndExecute;
-                };
-            } else {
-                ["springboard", _x] call FUNC(addUnitDamage);
-            };
             private _mult = 4;
-            if (_x isKindOf "landvehicle" || _x isKindOf "air") then {
+            if (_x isKindOf "LandVehicle" || _x isKindOf "Air") then {
                 if (getMass _x <= 10000) then {
                     _mult = _mult * 2;
                     private _curDam = _x getHitPointDamage "HitHull";
@@ -56,12 +47,16 @@ _trg setVariable [QGVAR(cooldown), true, true];
                 } else {
                     _mult = 1;
                 };
+            } else {
+                [{
+                    ["springboard", _this] call FUNC(addUnitDamage);
+                }, _x, [0.5, 0] select (isPlayer _x)] call CBA_fnc_waitAndExecute;
             };
             // [_x, [_a*_mult, _b*_mult, _mult + (5 / (1 + (abs _a) + (abs _b)))]] remoteExec ["setVelocity", _x];
             [QGVAR(setVelocity), [_x, [_a*_mult, _b*_mult, _mult + (5 / (1 + (abs _a) + (abs _b)))]], _x] call CBA_fnc_targetEvent;
             [QGVAR(springboardOnDamage), [_x, _trg]] call CBA_fnc_localEvent;
         } else {
-            if !(_x isKindOf "landvehicle" || _x isKindOf "air") then {
+            if !(_x isKindOf "LandVehicle" || _x isKindOf "Air") then {
                 [QGVAR(minceCorpse), [_x]] call CBA_fnc_globalEvent;
             };
         };

--- a/addons/main/functions/anomalies/fn_activateTeleport.sqf
+++ b/addons/main/functions/anomalies/fn_activateTeleport.sqf
@@ -16,12 +16,9 @@
     diwako 2017-12-14
 */
 params[["_trg",objNull],["_list",[]]];
+if (isNull _trg || !isServer || _trg getVariable [QGVAR(anomalyType),""] != "teleport") exitWith {};
 
-if !(isServer) exitWith {};
-if (isNull _trg) exitWith {};
-if (_trg getVariable [QGVAR(anomalyType),""] != "teleport") exitWith {};
-
-private _men = nearestObjects [getPos _trg,  ["Man","landvehicle"], 2];
+private _men = nearestObjects [getPos _trg,  ["Man", "landvehicle"], 2];
 private _id = _trg getVariable QGVAR(teleportID);
 private _teleporters = GVAR(teleportIDs) getOrDefault [_id, []];
 

--- a/addons/main/functions/anomalies/fn_createBurner.sqf
+++ b/addons/main/functions/anomalies/fn_createBurner.sqf
@@ -16,7 +16,7 @@
 */
 params[["_pos",[0,0,0]]];
 
-if (!isServer) exitWith {};
+if !(isServer) exitWith {};
 
 private _varName = "";
 if !(_pos isEqualType []) then {
@@ -37,12 +37,9 @@ _proxy enableSimulationGlobal false;
 _proxy setPos (_trg modelToWorld [0,0,0.5]);
 _trg setVariable [QGVAR(sound), _proxy, true];
 
-[QGVAR(setTrigger), [
-    _trg, //trigger
-    [4, 4, 0, false, 4], // area
-    ["ANY", "PRESENT", true], // activation
-    [format ["this and !(thisTrigger getVariable ['%1',false])", QGVAR(cooldown)], format ["[thisTrigger, thisList] call %1", QFUNC(activateBurner)], ""] // statements
-]] call CBA_fnc_globalEventJip;
+_trg setTriggerArea [4, 4, 0, false, 4];
+_trg setTriggerActivation ["ANY", "PRESENT", true];
+_trg setTriggerStatements [format ["this and !(thisTrigger getVariable ['%1',false])", QGVAR(cooldown)], format ["[thisTrigger, thisList] call %1", QFUNC(activateBurner)], ""];
 
 if (isNil QGVAR(holder)) then {
     GVAR(holder) = [];

--- a/addons/main/functions/anomalies/fn_createElectra.sqf
+++ b/addons/main/functions/anomalies/fn_createElectra.sqf
@@ -16,7 +16,7 @@
 */
 params[["_pos",[0,0,0]]];
 
-if (!isServer) exitWith {};
+if !(isServer) exitWith {};
 
 private _varName = "";
 if !(_pos isEqualType []) then {
@@ -37,12 +37,10 @@ private _proxy = "building" createVehicle position _trg;
 _proxy enableSimulationGlobal false;
 _proxy setPos (_trg modelToWorld [0,0,0.5]);
 _trg setVariable [QGVAR(sound), _proxy, true];
-[QGVAR(setTrigger), [
-    _trg, //trigger
-    [4, 4, 0, false,4], // area
-    ["ANY", "PRESENT", true], // activation
-    [format ["this and !(thisTrigger getVariable ['%1',false])", QGVAR(cooldown)], format ["[thisTrigger,thisList] call %1", QFUNC(activateElectra)], ""] // statements
-]] call CBA_fnc_globalEventJip;
+
+_trg setTriggerArea [4, 4, 0, false, 4];
+_trg setTriggerActivation ["ANY", "PRESENT", true];
+_trg setTriggerStatements [format ["this and !(thisTrigger getVariable ['%1',false])", QGVAR(cooldown)], format ["[thisTrigger,thisList] call %1", QFUNC(activateElectra)], ""];
 
 if (isNil QGVAR(holder)) then {
     GVAR(holder) = [];

--- a/addons/main/functions/anomalies/fn_createFruitPunch.sqf
+++ b/addons/main/functions/anomalies/fn_createFruitPunch.sqf
@@ -27,7 +27,7 @@ if (count _pos < 3) then {
     _pos set [2,0];
 };
 
-_trg = createTrigger ["EmptyDetector", _pos];
+private _trg = createTrigger ["EmptyDetector", _pos];
 if (_varName isNotEqualTo "") then { missionNamespace setVariable [_varName, _trg, true]; };
 _trg setPosASL _pos;
 _trg setVariable [QGVAR(cooldown), false, true];

--- a/addons/main/functions/anomalies/fn_createMeatgrinder.sqf
+++ b/addons/main/functions/anomalies/fn_createMeatgrinder.sqf
@@ -37,12 +37,10 @@ _proxy enableSimulationGlobal false;
 _proxy setPos (_trg modelToWorld [0,0,0.5]);
 
 _trg setVariable [QGVAR(sound), _proxy, true];
-[QGVAR(setTrigger), [
-    _trg, //trigger
-    [4, 4, 0, false,4], // area
-    ["ANY", "PRESENT", true], // activation
-    [format ["this and !(thisTrigger getVariable ['%1',false])", QGVAR(cooldown)], format ["[thisTrigger,thisList] call %1", QFUNC(activateMeatgrinder)], ""] // statements
-]] call CBA_fnc_globalEventJip;
+
+_trg setTriggerArea [4, 4, 0, false, 4];
+_trg setTriggerActivation ["ANY", "PRESENT", true];
+_trg setTriggerStatements [format ["this and !(thisTrigger getVariable ['%1',false])", QGVAR(cooldown)], format ["[thisTrigger,thisList] call %1", QFUNC(activateMeatgrinder)], ""];
 
 if (isNil QGVAR(holder)) then {
     GVAR(holder) = [];

--- a/addons/main/functions/anomalies/fn_createSpringboard.sqf
+++ b/addons/main/functions/anomalies/fn_createSpringboard.sqf
@@ -36,12 +36,10 @@ private _proxy = "building" createVehicle position _trg;
 _proxy enableSimulationGlobal false;
 _proxy setPos (_trg modelToWorld [0,0,0.5]);
 _trg setVariable [QGVAR(sound), _proxy, true];
-[QGVAR(setTrigger), [
-    _trg, //trigger
-    [4, 4, 0, false,4], // area
-    ["ANY", "PRESENT", true], // activation
-    [format ["this and !(thisTrigger getVariable ['%1',false])", QGVAR(cooldown)], format ["[thisTrigger,thisList] call %1", QFUNC(activateSpringboard)], ""] // statements
-]] call CBA_fnc_globalEventJip;
+
+_trg setTriggerArea [4, 4, 0, false, 4];
+_trg setTriggerActivation ["ANY", "PRESENT", true];
+_trg setTriggerStatements [format ["this and !(thisTrigger getVariable ['%1',false])", QGVAR(cooldown)], format ["[thisTrigger,thisList] call %1", QFUNC(activateSpringboard)], ""];
 
 if (isNil QGVAR(holder)) then {
   GVAR(holder) = [];

--- a/addons/main/functions/anomalies/fn_createTeleport.sqf
+++ b/addons/main/functions/anomalies/fn_createTeleport.sqf
@@ -54,12 +54,10 @@ private _proxy = "building" createVehicle position _trg;
 _proxy enableSimulationGlobal false;
 _proxy setPos (_trg modelToWorld [0,0,0.5]);
 _trg setVariable [QGVAR(sound), _proxy, true];
-[QGVAR(setTrigger), [
-    _trg, //trigger
-    [2, 2, 0, false,4], // area
-    ["ANY", "PRESENT", true], // activation
-    [format ["this and !(thisTrigger getVariable ['%1',false])", QGVAR(cooldown)], format ["[thisTrigger,thisList] call %1", QFUNC(activateTeleport)], ""] // statements
-]] call CBA_fnc_globalEventJip;
+
+_trg setTriggerArea [2, 2, 0, false, 4];
+_trg setTriggerActivation ["ANY", "PRESENT", true];
+_trg setTriggerStatements [format ["this and !(thisTrigger getVariable ['%1',false])", QGVAR(cooldown)], format ["[thisTrigger,thisList] call %1", QFUNC(activateTeleport)], ""];
 
 if (isNil QGVAR(holder)) then {
     GVAR(holder) = [];

--- a/addons/main/functions/effects/fn_burnerEffect.sqf
+++ b/addons/main/functions/effects/fn_burnerEffect.sqf
@@ -1,5 +1,5 @@
 #include "\z\diwako_anomalies\addons\main\script_component.hpp"
-params[["_source",objNull],["_state","idle"]];
+params[["_source",objNull], ["_state","idle"]];
 if (isNull _source) exitWith {};
 
 switch (_state) do {
@@ -10,24 +10,20 @@ switch (_state) do {
         _source setDropInterval 0.1;
     };
     case "active": {
-        if (isClass (configFile >> "CfgCloudlets" >> "ace_cookoff_CookOff")) then {
-            _source setParticleClass "ace_cookoff_CookOff";
-        } else {
-            _source setParticleCircle [0, [2,2,2]];
-            _source setParticleParams [["\A3\data_f\ParticleEffects\Universal\Universal",16,0,32,0],"","billboard",1,1,
-            [0,0,0], //position
-            [0,0,4], //move velocity
-            1, //rotationVelocity
-            0.4, //weight
-            0.45, //volume
-            0, // rubbing
-            [0.01,0.5,1,1,1.5,0.01,0.001], //size
-            [[1,1,1,-4],[1,1,1,-3],[1,1,1,-2],[1,1,1,-1],[1,1,1,0]], //color
-            [1], 0.01, 0.02, "", "", "",0,true,0.6,[[3,3,3,0]]];
-            _source setParticleRandom [0, [0,0,0], [0,0,0], 0, 0, [0,0,0,0], 5, 1, 0.2];
-            // _source setParticleFire [0.6*2, 0.25*2, 0.1];
-            _source setDropInterval 0.004;
-        };
+        _source setParticleCircle [0, [2,2,2]];
+        _source setParticleParams [["\A3\data_f\ParticleEffects\Universal\Universal",16,0,32,0],"","billboard",1,1,
+        [0,0,0], //position
+        [0,0,4], //move velocity
+        1, //rotationVelocity
+        0.4, //weight
+        0.45, //volume
+        0, // rubbing
+        [0.01,0.5,1,1,1.5,0.01,0.001], //size
+        [[1,1,1,-4],[1,1,1,-3],[1,1,1,-2],[1,1,1,-1],[1,1,1,0]], //color
+        [1], 0.01, 0.02, "", "", "",0,true,0.6,[[3,3,3,0]]];
+        _source setParticleRandom [0, [0,0,0], [0,0,0], 0, 0, [0,0,0,0], 5, 1, 0.2];
+        // _source setParticleFire [0.6*2, 0.25*2, 0.1];
+        _source setDropInterval 0.004;
     };
     default { };
 };


### PR DESCRIPTION
Switches the detection of anomaly activation for most anomalies to server only.
Why? There were reports that anomalies activated but on the players' screens no effects were shown. This was due to an overload of the scheduler, which triggers rely on. Meaning if there is some mission script or mod that overloads the scheduler, a race condition is happening, the server marked the anomaly to be on cooldown for the player, and the trigger on the players machine was not fast enough to activate.

This means if the anomaly gets activated on server, the sever will send the message to all clients to play the effects. There might be a delay, but that was there before and no one noticed anyways.